### PR TITLE
Support showing hidden elements when downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ You can remove elements adding the class **"remove-when-downloading"**.
 
 Remove Elements apply `display: none` to the elements. So the space into the element will remove.
 
+## Show Elements
+
+You can show elements by adding the class **"show-when-downloading"**.
+
+Show elements apply `display: inherit` to the elements with this class;
 
 ## Browsers
 It's tested on the lasted Chrome (Chrome 76),  Firefox and *Safari*.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "save-html-as-image",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Save the html as image like png or jpg",
   "source": "src/index.js",
   "main": "dist/index.js",

--- a/src/utils.js
+++ b/src/utils.js
@@ -171,6 +171,18 @@ const removeElements = (node) => {
   }
 };
 
+const showElements = (node) => {
+  const els = node.querySelectorAll(['.show-when-downloading']);
+
+  for (const element of els) {
+    element.setAttribute(
+      'original_display',
+      window.getComputedStyle(element).display
+    );
+    element.style.display = 'inherit';
+  }
+};
+
 const recoveryElements = (node) => {
   const els = node.querySelectorAll(['.remove-when-downloading']);
 
@@ -206,6 +218,7 @@ export const scaffolding = async (
   applyFixs(node, options.forceFixText);
 
   removeElements(node);
+  showElements(node);
 
   try {
     canvas = await callback();

--- a/src/utils.js
+++ b/src/utils.js
@@ -184,7 +184,7 @@ const showElements = (node) => {
 };
 
 const recoveryElements = (node) => {
-  const els = node.querySelectorAll(['.remove-when-downloading']);
+  const els = node.querySelectorAll(['.remove-when-downloading','.show-when-downloading']);
 
   for (const element of els) {
     element.style.display = element.getAttribute('original_display');


### PR DESCRIPTION
Usecase:
I have a page where there is a hidden logo and I only want it to be present when downloading.